### PR TITLE
Edited check answers to match Chaffinch, Kestrel and Goldeneye

### DIFF
--- a/app/views/v9/book-appt/check-answers.html
+++ b/app/views/v9/book-appt/check-answers.html
@@ -176,13 +176,17 @@ Check appointment details - GOV.UK prototype
                 {% if  data['more-detail'] %}
                 {{ data['more-detail'] }}
                {% else %}
-               None
+               
                {% endif %}
 
               </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href="more-info">
-                  Change<span class="govuk-visually-hidden"> any additional information</span>
+                  {% if  data['more-detail'] %}
+                 Change
+               {% else %}
+               Add
+               {% endif %} <span class="govuk-visually-hidden"> any additional information</span>
                 </a>
               </dd>
             </div>


### PR DESCRIPTION
When a field has not been completed, the change link becomes an "Add" link, and the field remains blank. This is because users can miss that the content is  simply placeholder text, and that they haven't entered anything themselves.